### PR TITLE
Fix path errors caused by percentEncoded.

### DIFF
--- a/XCStringGPTTranslator/ContentView.swift
+++ b/XCStringGPTTranslator/ContentView.swift
@@ -121,9 +121,8 @@ struct ContentView: View {
         NavigationSplitView {
             VStack(alignment: .leading) {
                 List(gptServices.map(\.target), selection: $selectGptServicesTarget) { target in
-                    let title = target.xcstringURL.absoluteString
-                        .replacingOccurrences(of: rootDirectory?.absoluteString ?? "", with: "")
-                        .replacingOccurrences(of: "file://", with: "")
+                    let title = target.xcstringURL.path(percentEncoded: false)
+                        .replacingOccurrences(of: rootDirectory?.path(percentEncoded: false) ?? "", with: "")
                     NavigationLink(value: target) {
                         Text(title)
                             .lineLimit(0)
@@ -141,9 +140,8 @@ struct ContentView: View {
 
         } detail: {
             if let selectGptServicesTarget, let service = gptServices.first(where: { $0.target == selectGptServicesTarget }) {
-                let title = selectGptServicesTarget.xcstringURL.absoluteString
-                    .replacingOccurrences(of: rootDirectory?.absoluteString ?? "", with: "")
-                    .replacingOccurrences(of: "file://", with: "")
+                let title = selectGptServicesTarget.xcstringURL.path(percentEncoded: false)
+                    .replacingOccurrences(of: rootDirectory?.path(percentEncoded: false) ?? "", with: "")
 
                 GPTProcessView(gptService: service)
                     .id(service.target.hashValue)

--- a/XCStringGPTTranslator/GPTService .swift
+++ b/XCStringGPTTranslator/GPTService .swift
@@ -89,7 +89,7 @@ class GPTService {
             }
         }
 
-        let xcodeproj = try XcodeProj(path: Path(target.xcprojURL.path()))
+        let xcodeproj = try XcodeProj(path: Path(target.xcprojURL.path(percentEncoded: false)))
         langs = Set(langs).union(xcodeproj.pbxproj.rootObject?.knownRegions ?? []).sorted()
         langs.removeAll(where: { $0 == "Base" })
 

--- a/XCStringGPTTranslator/GPTServiceOpenButtonView.swift
+++ b/XCStringGPTTranslator/GPTServiceOpenButtonView.swift
@@ -29,7 +29,7 @@ struct GPTServiceOpenButtonView: View {
                     }
                 }
                 if let projURL {
-                    Text(projURL.path())
+                    Text(projURL.path(percentEncoded: false))
                 }
             }
 
@@ -44,7 +44,7 @@ struct GPTServiceOpenButtonView: View {
                     }
                 }
                 if let xcstringsURL {
-                    Text(xcstringsURL.path())
+                    Text(xcstringsURL.path(percentEncoded: false))
                 }
             }
         }


### PR DESCRIPTION
If the selected project path contains spaces, it will prompt that the **xcstrings** file cannot be found.