### PR TITLE
Add support for LM Studio as an API provider

### DIFF
--- a/XCStringGPTTranslator/SettingService.swift
+++ b/XCStringGPTTranslator/SettingService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import ObservableUserDefault
+import Combine
 
 @Observable
 class SettingService {
@@ -27,9 +28,70 @@ class SettingService {
     @ObservationIgnored
     var modelList: [String] = ["gpt-4o-mini", "gpt-4o", "gpt-o1-mini", "gpt-o3-mini"]
 
+    enum APIProvider: String, CaseIterable, Identifiable, Codable {
+        case openAI = "openai"
+        case lmStudio = "lmstudio"
+        var id: String { rawValue }
+        var displayName: String {
+            switch self {
+            case .openAI: return "ChatGPT"
+            case .lmStudio: return "LM Studio"
+            }
+        }
+    }
+    @ObservableUserDefault(.init(key: "api-provider", defaultValue: APIProvider.openAI.rawValue, store: .standard))
+    @ObservationIgnored private var apiProviderRaw: String
+    var apiProvider: APIProvider {
+        get { APIProvider(rawValue: apiProviderRaw) ?? .openAI }
+        set { apiProviderRaw = newValue.rawValue }
+    }
+
+    @ObservableUserDefault(.init(key: "lmstudio-url", defaultValue: "http://localhost:1234", store: .standard))
+    @ObservationIgnored var lmStudioURL: String
+    @ObservableUserDefault(.init(key: "lmstudio-model", defaultValue: "", store: .standard))
+    @ObservationIgnored var lmStudioModel: String
+    var lmStudioModels: [String] = []
+
+    /// Ping `/api/v1/models` to verify LM Studio is alive
+    func testLMStudioConnection() async -> Bool {
+        let base = lmStudioURL.hasSuffix("/") ? String(lmStudioURL.dropLast()) : lmStudioURL
+        guard let url = URL(string: base + "/v1/models") else { return false }
+        var req = URLRequest(url: url); req.httpMethod = "GET"
+        do {
+            let (_, resp) = try await URLSession.shared.data(for: req)
+            return (resp as? HTTPURLResponse)?.statusCode == 200
+        } catch { return false }
+    }
+
+    /// Fetch model list from LM Studio
+    func fetchLMStudioModels() async {
+        let base = lmStudioURL.hasSuffix("/") ? String(lmStudioURL.dropLast()) : lmStudioURL
+        guard let url = URL(string: base + "/v1/models") else { return }
+        var req = URLRequest(url: url)
+        req.httpMethod = "GET"
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: req)
+            guard (resp as? HTTPURLResponse)?.statusCode == 200 else { return }
+            struct ModelInfo: Codable { let id: String }
+            struct ListResponse: Codable { let data: [ModelInfo] }
+            let list = try JSONDecoder().decode(ListResponse.self, from: data)
+            let ids = list.data.map(\.id)
+            DispatchQueue.main.async {
+                self.lmStudioModels = ids
+                if !ids.contains(self.lmStudioModel) {
+                    self.lmStudioModel = ids.first ?? ""
+                }
+            }
+        } catch {
+            print("LM Studio fetch error:", error)
+        }
+    }
+
     init() {
         if model.isEmpty || !modelList.contains(model) {
             model = modelList[0]
         }
     }
 }
+
+extension SettingService: @unchecked Sendable {}

--- a/XCStringGPTTranslator/SettingView.swift
+++ b/XCStringGPTTranslator/SettingView.swift
@@ -10,42 +10,118 @@ import SwiftUI
 struct SettingView: View {
     @Environment(\.dismiss) var dismiss
     @State var settingService = SettingService.shared
+    @State private var testConnectionOK: Bool?    = nil
+    @State private var refreshModelsOK: Bool?     = nil
 
     var body: some View {
         NavigationStack {
             VStack(spacing: 30) {
                 VStack(spacing: 0) {
                     HStack {
-                        Text("GPT API Key")
+                        Text("Provider")
                             .frame(width: 80, alignment: .trailing)
-                        SecureField("API Key", text: $settingService.gptAPIKey)
-                    }
-                    .frame(height: 44)
-
-                    HStack {
-                        Text("OpenAI endpoint (Optional)")
-                            .frame(width: 80, alignment: .trailing)
-
-                        let defaultUrl = "https://api.openai.com"
-                        TextField(defaultUrl, text: $settingService.gptServer)
-                    }
-                    .frame(height: 44)
-
-                    HStack {
-                        Text("Model")
-                            .frame(width: 80, alignment: .trailing)
-                        Picker("", selection: $settingService.model) {
-                            ForEach(settingService.modelList, id: \.self) { model in
-                                Text(model).tag(model)
+                        Picker("", selection: $settingService.apiProvider) {
+                            ForEach(SettingService.APIProvider.allCases) { p in
+                                Text(p.displayName).tag(p)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .onChange(of: settingService.apiProvider) { old, newProvider in
+                            if newProvider == .lmStudio {
+                                Task {
+                                    testConnectionOK = await settingService.testLMStudioConnection()
+                                    await settingService.fetchLMStudioModels()
+                                    refreshModelsOK = !settingService.lmStudioModels.isEmpty
+                                }
                             }
                         }
                     }
                     .frame(height: 44)
+
+                    if settingService.apiProvider == .openAI {
+                        HStack {
+                            Text("API Key")
+                                .frame(width: 80, alignment: .trailing)
+                            SecureField("API Key", text: $settingService.gptAPIKey)
+                        }
+                        .frame(height: 44)
+                        HStack {
+                            Text("OpenAI endpoint (Optional)")
+                                .frame(width: 80, alignment: .trailing)
+                            TextField("https://api.openai.com", text: $settingService.gptServer)
+                                .disableAutocorrection(true)
+                                .textContentType(.URL)
+                        }
+                        .frame(height: 44)
+                        HStack {
+                            Text("Model")
+                                .frame(width: 80, alignment: .trailing)
+                            Picker("", selection: $settingService.model) {
+                                ForEach(settingService.modelList, id: \.self) {
+                                    Text($0).tag($0)
+                                }
+                            }
+                        }
+                        .frame(height: 44)
+                    }
+                    
+                    else {
+                        HStack {
+                            Text("URL")
+                                .frame(width: 80, alignment: .trailing)
+                            TextField("http://localhost:1234", text: $settingService.lmStudioURL)
+                                .disableAutocorrection(true)
+                                .textContentType(.URL)
+                        }
+                        .frame(height: 44)
+                        HStack(spacing: 16) {
+                            Button("Test Connection") {
+                                Task {
+                                    let ok = await settingService.testLMStudioConnection()
+                                    testConnectionOK = ok
+                                }
+                            }
+                            if let ok = testConnectionOK {
+                                Image(systemName: ok ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                    .foregroundStyle(ok ? Color.green : Color.red)
+                            }
+
+                            Button("Refresh Models") {
+                                Task {
+                                    await settingService.fetchLMStudioModels()
+                                    refreshModelsOK = !settingService.lmStudioModels.isEmpty
+                                }
+                            }
+                            if let ok = refreshModelsOK {
+                                Image(systemName: ok ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                    .foregroundStyle(ok ? Color.green : Color.red)
+                            }
+                        }
+                        .frame(height: 44)
+                        HStack {
+                            Text("Model")
+                                .frame(width: 80, alignment: .trailing)
+                            Picker("", selection: $settingService.lmStudioModel) {
+                                ForEach(settingService.lmStudioModels, id: \.self) {
+                                    Text($0).tag($0)
+                                }
+                            }
+                        }
+                        .frame(height: 44)
+                    }
                 }
 
                 Spacer()
             }
             .padding(24)
+            .task {
+                if settingService.apiProvider == .lmStudio {
+                    testConnectionOK   = await settingService.testLMStudioConnection()
+                    await settingService.fetchLMStudioModels()
+                    refreshModelsOK    = !settingService.lmStudioModels.isEmpty
+                }
+            }
+            
             .frame(width: 400, height: 300)
             .navigationTitle("Settings")
         }


### PR DESCRIPTION
Enable running locally without OpenAI API keys.

- Added APIProvider enum with options for OpenAI and LM Studio
- Introduced settings for LM Studio URL and model
- Updated request logic to support LM Studio
- UI changes in settings view to configure and test LM Studio
- Fetches available models from LM Studio and allows selection

